### PR TITLE
Remove exclusion, use optional for spring-boot-starter-web

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,12 +109,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.springframework.boot</groupId>
-                    <artifactId>spring-boot-starter-tomcat</artifactId>
-                </exclusion>
-            </exclusions>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Exclude spring-boot-starter-tomcat causes errors.

See samples : https://github.com/speralta/spring-boot-ext-logback-access-sample
